### PR TITLE
fix : posting 상세 보기 쿼리 fetchjoin 문제 해결

### DIFF
--- a/src/main/kotlin/com/kotlin/sns/domain/Posting/repository/Impl/PostingRepositoryCustomImpl.kt
+++ b/src/main/kotlin/com/kotlin/sns/domain/Posting/repository/Impl/PostingRepositoryCustomImpl.kt
@@ -23,7 +23,7 @@ class PostingRepositoryCustomImpl(
     override fun findByIdForDetail(postingId: Long): Optional<Posting> {
         val posting =  jpaQueryFactory
             .selectFrom(qPosting)
-            .leftJoin(qPosting.imageInPosting, qImage).fetchJoin()
+            .leftJoin(qPosting.imageInPosting, qImage)
             .leftJoin(qPosting.comment, qComment).fetchJoin()
             .leftJoin(qComment.member, qMember).fetchJoin()
             .where(qPosting.id.eq(postingId))

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -9,6 +9,7 @@ spring:
       ddl-auto: update
     show-sql: true
     properties:
+      hibernate.default_batch_fetch_size: 1000    #batch size설정해서 n + 1 문제 해결
       hibernate:
         format_sql: true
   rabbitmq:


### PR DESCRIPTION
oneToMany 두 개 이상 필드에 fetchjoin 걸면 오류 발생
한 자식 테이블에게만 fetchjoin을 걸고, application.yml에 batch size를 설정해서 해결